### PR TITLE
Improve hwmon property descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ please run "gcc keymap.c -o keymap" in keymap directory to get a valid binary.
 python3 -m nuitka main.py   --plugin-enable=numpy,pyside2 --show-progress --follow-imports  --plugin-enable=pylint-warnings  --nofollow-import-to=numpy
 
 
+## hwmon sensors
+
+The application reads sensor values from the Linux *hwmon* subsystem.
+Properties discovered from `/sys/class/hwmon` now provide better
+descriptions based on the channel name or the optional `*_label` files.
+Threshold attributes such as `*_max`, `*_crit` or `*_lcrit_alarm` are
+recognised and described accordingly. Alarm, fault, beep and intrusion
+files are detected too. Additionally the new `FREQUENCY` datatype and
+power capping attributes are understood.
+
+
 
 
 

--- a/core/DataTypes.py
+++ b/core/DataTypes.py
@@ -60,6 +60,9 @@ class DataType(Enum):
     DIRECTION = 37  # degrees 0-360′
     HEIGHT = 38  # mm
 
+    # Additional sensor types
+    FREQUENCY = 39  # Hertz
+
     # Electricity (from sensors)
     CURRENT = 40  # float, Ampere
     VOLTAGE = 41  # float, Volt
@@ -172,6 +175,7 @@ class Convert:
                          DataType.CONCENTRATION: 'concentration',
                          DataType.UVINDEX: 'uvindex',
                          DataType.GRAVITY: 'gravity',
+                         DataType.FREQUENCY: 'frequency',
                          DataType.CURRENT: 'current',
                          DataType.VOLTAGE: 'voltage',
                          DataType.RESISTANCE: 'resistance',

--- a/core/HWMon.py
+++ b/core/HWMon.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 from functools import partial
+import fnmatch
 
 from core.DataTypes import Convert, DataType
 from core.Property import EntityProperty
@@ -15,6 +16,76 @@ class HWMon:
         super(HWMon, self).__init__()
         self._hwmon = list()
 
+        base_map = {
+            'temp': 'Temperature',
+            'curr': 'Current',
+            'in': 'Voltage',
+            'power': 'Power',
+            'energy': 'Energy',
+            'charge': 'Charge',
+            'humidity': 'Humidity',
+            'fan': 'Fan speed',
+            'freq': 'Frequency',
+            'pwm': 'PWM output',
+            'buzzer': 'Buzzer control',
+            'relay': 'Relay control',
+            'beep': 'Beep control',
+            'intrusion': 'Chassis intrusion',
+            'vrm': 'VRM version'
+        }
+
+        suffix_map = [
+            ('*_lcrit_alarm', 'lower critical alarm status'),
+            ('*_crit_alarm', 'critical alarm status'),
+            ('*_min_alarm', 'minimum alarm status'),
+            ('*_max_alarm', 'maximum alarm status'),
+            ('*_cap_alarm', 'cap alarm status'),
+            ('*_alarm', 'alarm status'),
+            ('*_fault', 'fault status'),
+            ('*_beep', 'beep control'),
+            ('*_hyst', 'hysteresis value'),
+            ('*_cap_hyst', 'cap hysteresis'),
+            ('*_cap_max', 'maximum cap limit'),
+            ('*_cap_min', 'minimum cap limit'),
+            ('*_cap', 'cap limit'),
+            ('*_offset', 'offset'),
+            ('*_target', 'target setting'),
+            ('*_pulses', 'tach pulses per revolution'),
+            ('*_div', 'clock divisor'),
+            ('*_average_interval', 'averaging interval'),
+            ('*_average_highest', 'historical average high'),
+            ('*_average_lowest', 'historical average low'),
+            ('*_average', 'average value'),
+            ('*_highest', 'historical maximum'),
+            ('*_lowest', 'historical minimum'),
+            ('*_reset_history', 'reset history'),
+            ('*_lcrit', 'lower critical limit'),
+            ('*_crit', 'critical limit'),
+            ('*_min', 'minimum limit'),
+            ('*_max', 'maximum limit'),
+            ('*_enable', 'enable switch'),
+            ('*_input', 'input'),
+            ('beep_enable', 'master beep enable'),
+        ]
+
+        def make_desc(name: str, label: str = '') -> str:
+            base_desc = ''
+            for key, desc in base_map.items():
+                if name.startswith(key):
+                    base_desc = desc
+                    break
+
+            suffix_desc = ''
+            for pattern, desc in suffix_map:
+                if fnmatch.fnmatch(name, pattern):
+                    suffix_desc = desc
+                    break
+
+            result = ' '.join(filter(None, [base_desc, suffix_desc])).strip()
+            if label:
+                return f"{result} ({label})" if result else label
+            return result
+
         for sensors in glob.iglob('/sys/class/hwmon/hwmon*', recursive=False):
 
             if os.path.isfile(sensors + '/name'):
@@ -26,22 +97,27 @@ class HWMon:
             sensors = sensors.split('/')
             sensor_id = sensors[-1]
 
-            for channeltype in ('input', 'alarm', 'enable'):
+            for channeltype in (
+                    'input', 'alarm', 'enable', 'fault', 'beep',
+                    'max', 'min', 'crit', 'lcrit', 'hyst', 'offset',
+                    'cap', 'cap_alarm', 'cap_hyst'):
                 for filename in glob.iglob(f"/sys/class/hwmon/{sensor_id}/*_{channeltype}"):
 
-                    channel_desc = ''
-                    if os.path.isfile(filename[0:-len(channeltype)] + "label"):
-                        try:
-                          with open(filename[0:-len(channeltype)] + "label", 'r') as rf:
-                            channel_desc = (rf.read().rstrip())
-                        except:
-                            channel_desc = "read error"
-                            pass
                     channel_type = DataType.UNDEFINED
                     channel_is_output = (os.stat(filename).st_mode & 0o444 == 0o444)
 
-                    filename = filename.split('/')
-                    channel_channel = filename[-1]
+                    filename_parts = filename.split('/')
+                    channel_channel = filename_parts[-1]
+
+                    label = ''
+                    if os.path.isfile(filename[0:-len(channeltype)] + "label"):
+                        try:
+                            with open(filename[0:-len(channeltype)] + "label", 'r') as rf:
+                                label = rf.read().rstrip()
+                        except Exception:
+                            label = "read error"
+
+                    channel_desc = make_desc(channel_channel, label)
 
                     if channeltype == 'input':
                         if channel_channel.startswith('temp'):
@@ -52,15 +128,38 @@ class HWMon:
                             channel_type = DataType.VOLTAGE
                         elif channel_channel.startswith('power'):
                             channel_type = DataType.POWER
+                        elif channel_channel.startswith('energy'):
+                            channel_type = DataType.ENERGY
+                        elif channel_channel.startswith('charge'):
+                            channel_type = DataType.WORK
                         elif channel_channel.startswith('humidity'):
                             channel_type = DataType.HUMIDITY
                         elif channel_channel.startswith('fan'):
                             channel_type = DataType.FAN
+                        elif channel_channel.startswith('freq'):
+                            channel_type = DataType.FREQUENCY
 
-                    if channeltype == 'enable':
+                    if channeltype in ('enable', 'alarm', 'fault', 'beep', 'cap_alarm'):
                         channel_type = DataType.BOOL
-                    if channeltype == 'alarm':
-                        channel_type = DataType.BOOL
+                    if channeltype in ('max', 'min', 'crit', 'lcrit', 'hyst', 'offset', 'cap', 'cap_hyst'):
+                        if channel_channel.startswith('temp'):
+                            channel_type = DataType.TEMPERATURE
+                        elif channel_channel.startswith('curr'):
+                            channel_type = DataType.CURRENT
+                        elif channel_channel.startswith('in'):
+                            channel_type = DataType.VOLTAGE
+                        elif channel_channel.startswith('power'):
+                            channel_type = DataType.POWER
+                        elif channel_channel.startswith('energy'):
+                            channel_type = DataType.ENERGY
+                        elif channel_channel.startswith('charge'):
+                            channel_type = DataType.WORK
+                        elif channel_channel.startswith('humidity'):
+                            channel_type = DataType.HUMIDITY
+                        elif channel_channel.startswith('fan'):
+                            channel_type = DataType.FAN
+                        elif channel_channel.startswith('freq'):
+                            channel_type = DataType.FREQUENCY
 
                     self._hwmon.append(EntityProperty(
                                                       category='sensor/' + sensor_name,
@@ -74,14 +173,22 @@ class HWMon:
 
             for channeltype in ('pwm', 'buzzer', 'relay'):
                 for filename in glob.iglob(f"/sys/class/hwmon/{sensor_id}/{channeltype}[0-9]"):
-                    channel_desc = ''
-                    if os.path.isfile(filename + "_label"):
-                        with open(filename + "_label", 'r') as rf:
-                            channel_desc = (rf.read().rstrip())
+
                     channel_type = DataType.BYTE if (channeltype == 'pwm') else DataType.BOOL
                     channel_is_output = (os.stat(filename).st_mode & 0o444 == 0o444)
-                    filename = filename.split('/')
-                    channel_channel = filename[-1]
+
+                    filename_parts = filename.split('/')
+                    channel_channel = filename_parts[-1]
+
+                    label = ''
+                    if os.path.isfile(filename + "_label"):
+                        try:
+                            with open(filename + "_label", 'r') as rf:
+                                label = rf.read().rstrip()
+                        except Exception:
+                            label = "read error"
+
+                    channel_desc = make_desc(channel_channel, label)
                     min=0
                     step=1
                     max=1


### PR DESCRIPTION
## Summary
- expand hwmon suffix recognition for alarms, beeps and power-capping parameters
- map additional base names like intrusion and beep to readable descriptions
- note detection of alarm and power cap attributes in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68660ea51eb08329a6c0707d714697f4